### PR TITLE
Adjust test #get response to require #get.strip

### DIFF
--- a/spec/02_cli_spec.rb
+++ b/spec/02_cli_spec.rb
@@ -13,7 +13,7 @@ describe './bin/greet executing a CLI Application' do
   it 'uses #gets.strip to capture the user input and set it equal to a variable called name' do 
     allow($stdout).to receive(:puts)
     
-    expect(self).to receive(:gets).and_return("Don")
+    expect(self).to receive(:gets).and_return("Don ")
     name = get_variable_from_file("./bin/greet", "name")
 
     expect(name).to eq("Don")


### PR DESCRIPTION
Current test passes a #get in the greet executable file, as the input doesn't require the strip in order to return the expected response. Adjusted response to #get in order to require #get.strip in the greet executable file.